### PR TITLE
Remove reference to parameter in default value

### DIFF
--- a/cute/ostream_listener.h
+++ b/cute/ostream_listener.h
@@ -30,7 +30,7 @@ namespace cute {
 		std::ostream &out;
 	public:
 		ostream_listener(std::ostream &os=std::cerr):out(os) {}
-		void begin(suite const &t,char const *info, size_t n_of_tests=t.size()){
+		void begin(suite const &t,char const *info, size_t n_of_tests){
 			out << "beginning: " << info << std::endl;
 			Listener::begin(t,info, n_of_tests);
 		}


### PR DESCRIPTION
ISO-14882:2014 (and as far as I can tell also the prior versions)
forbids the use of function parameters in the initializer-clause of a
parameter-declaration (see dcl.fct.default). Even though this general
ban was lifted a little bit - by allowing usage in non-evaluated
contexts - in CWG2082, this change does not apply here.
