### PR TITLE
Match tuple output format with the one of vector

### DIFF
--- a/cute/cute_to_string.h
+++ b/cute/cute_to_string.h
@@ -156,7 +156,8 @@ namespace cute_to_string {
 		struct empty { template<typename ...Types>empty(Types const &...){} };
 		template<typename ...Types, std::size_t _, std::size_t Head, std::size_t ...Indices>
 		std::ostream &print_tuple(std::ostream &os, std::tuple<Types...> const &t, size<_> const, index_sequence<Head, Indices...>){
-			empty{cute_to_string::to_stream(os, std::get<Head>(t))
+			empty{os << '\n'
+			      ,cute_to_string::to_stream(os, std::get<Head>(t))
 			      ,(os << ",\n", cute_to_string::to_stream(os, std::get<Indices>(t)))...};
 			return os;
 		}
@@ -166,7 +167,7 @@ namespace cute_to_string {
 		}
 		template<typename ..._>
 		std::ostream &print_tuple(std::ostream &os, std::tuple<_...> const &t, size<1> const){
-			return cute_to_string::to_stream(os, std::get<0>(t));
+			return os << '\n', cute_to_string::to_stream(os, std::get<0>(t));
 		}
 		template<typename ..._>
 		std::ostream &print_tuple(std::ostream &os, std::tuple<_...> const &, size<0>){

--- a/cute/cute_to_string.h
+++ b/cute/cute_to_string.h
@@ -157,7 +157,7 @@ namespace cute_to_string {
 		template<typename ...Types, std::size_t _, std::size_t Head, std::size_t ...Indices>
 		std::ostream &print_tuple(std::ostream &os, std::tuple<Types...> const &t, size<_> const, index_sequence<Head, Indices...>){
 			empty{cute_to_string::to_stream(os, std::get<Head>(t))
-			      ,(os << ',', cute_to_string::to_stream(os, std::get<Indices>(t)))...};
+			      ,(os << ",\n", cute_to_string::to_stream(os, std::get<Indices>(t)))...};
 			return os;
 		}
 		template<typename ...Types, std::size_t _, std::size_t ...Indices>

--- a/cute/cute_to_string.h
+++ b/cute/cute_to_string.h
@@ -160,7 +160,7 @@ namespace cute_to_string {
 			      ,(os << ",\n", cute_to_string::to_stream(os, std::get<Indices>(t)))...};
 			return os;
 		}
-		template<typename ...Types, std::size_t _, std::size_t ...Indices>
+		template<typename ...Types, std::size_t _>
 		std::ostream &print_tuple(std::ostream &os, std::tuple<Types...> const &t, size<_> const s) {
 			return print_tuple(os, t, s, index_sequence_for<Types...>{});
 		}


### PR DESCRIPTION
CUTE prints each element of a std::vector<T> on its own separate line.
This makes reading the diff in CDT much easier. This patchset changes
the output function for std::tuple<T...> to do the same thing.