### PR TITLE
Fix demangling for GNU's libstdc++ C++11 ABI

### DIFF
--- a/cute/cute_demangle.h
+++ b/cute/cute_demangle.h
@@ -38,13 +38,18 @@ inline std::string plain_demangle(char const *name){
 	::free(const_cast<char*>(toBeFreed));
 	return result;
 }
-#ifdef _LIBCPP_NAMESPACE
+#if defined(_LIBCPP_NAMESPACE) || defined(_GLIBCXX_USE_CXX11_ABI)
 inline void patch_library_namespace(std::string &mightcontaininlinenamespace) {
 // libc++ uses inline namespace std::_LIBCPP_NAMESPACE:: for its classes. This breaks the tests relying on meta information. re-normalize the names back to std::
+// libstdc++ (at least in version 6.3.1) puts some STL classes into the inline namespace std::_GLIBCXX_NAMESPACE_CXX11 if in C++11 mode
 	std::string::size_type pos=std::string::npos;
 #define XNS(X) #X
 #define NS(X) XNS(X)
+#ifdef _LIBCPP_NAMESPACE
 #define TOREPLACE "::" NS(_LIBCPP_NAMESPACE)
+#else
+#define TOREPLACE "::" NS(_GLIBCXX_NAMESPACE_CXX11)
+#endif
 	std::string const nothing;
 	while (std::string::npos != (pos= mightcontaininlinenamespace.find(TOREPLACE)))
 			mightcontaininlinenamespace.erase(pos,sizeof(TOREPLACE)-1);
@@ -67,7 +72,7 @@ inline void patchresultforstring(std::string& result) {
 inline std::string demangle(char const *name){
 	if (!name) return "unknown";
 	std::string result(cute_impl_demangle::plain_demangle(name));
-#ifdef _LIBCPP_NAMESPACE
+#if defined(_LIBCPP_NAMESPACE) || defined(_GLIBCXX_USE_CXX11_ABI)
 	cute_impl_demangle::patchresultforstring(result);
 #endif
 	return result;


### PR DESCRIPTION
When using the C++11 ABI, GNU's libstdc++ puts some classes, most notably map, into an inline namespace _GLIBCXX_USE_CXX11_ABI. This broke four of CUTE's own unit tests.