### PR TITLE
Implement TAP listener

### DIFF
--- a/cute/tap_listener.h
+++ b/cute/tap_listener.h
@@ -1,0 +1,81 @@
+/*********************************************************************************
+ * This file is part of CUTE.
+ *
+ * CUTE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CUTE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with CUTE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2017 Felix Morgner <felix.morgner@gmail.com>
+ *
+ *********************************************************************************/
+
+#ifndef TAP_LISTENER_H_
+#define TAP_LISTENER_H_
+
+#include <cstdint>
+#include <iostream>
+
+#include "cute_listener.h"
+
+namespace cute {
+
+	template<typename Listener=null_listener>
+	struct tap_listener : Listener {
+		tap_listener(std::ostream & out = std::cout) : out{out} { }
+
+		~tap_listener() {
+			if (nofTests) {
+				out << "1.." << nofTests << '\n';
+			}
+		}
+
+		void begin(suite const & suite, char const * info, size_t n_of_tests) {
+			out << "# Starting suite '" << info << "' containing " << n_of_tests << " tests\n";
+			Listener::begin(suite, info, n_of_tests);
+		}
+
+		void end(suite const & suite, char const * info) {
+			out << "# Ending suite '" << info << "'\n";
+			Listener::end(suite, info);
+		}
+
+		void start(test const & test) {
+			++nofTests;
+			Listener::start(test);
+		}
+
+		void success(test const & test, char const * msg) {
+			out << "ok " << nofTests << ' ' << test.name() << '\n';
+			Listener::success(test, msg);
+		}
+
+		void failure(test const & test, test_failure const & reason) {
+			out << "not ok " << nofTests << ' ' << test.name() << '\n';
+			out << "# Assertion failed: " << reason.what() << '\n';
+			Listener::failure(test, reason);
+		}
+
+		void error(test const & test, char const * what) {
+			out << "not ok " << nofTests << ' ' << test.name() << '\n';
+			out << "# Unexpected exception: " << what << '\n';
+			Listener::error(test, what);
+		}
+
+	private:
+		std::ostream & out;
+		std::size_t nofTests{};
+	};
+
+}
+
+#endif /* TAP_LISTENER_H_ */
+

--- a/cute_tests/main.cpp
+++ b/cute_tests/main.cpp
@@ -42,6 +42,7 @@
 #include "test_cute_filter_runner.h"
 #include "test_cute_relops.h"
 #include "test_cute_data_driven.h"
+#include "test_tap_listener.h"
 
 using namespace cute;
 // some brain dead test cases to find out my bug using function
@@ -105,6 +106,7 @@ int main(int argc, char const *argv[]){
 	s += make_suite_test_xml_listener();
 	s += make_suite_test_xml_file_opener();
 	s += make_suite_test_cute_to_string_embedded();
+	s += make_suite_test_tap_listener();
 	s += test_cute_to_string();
 	s += test_cute_equals();
 	// the following test produces one of the 2 expected errors, since it throws

--- a/cute_tests/test_tap_listener.cpp
+++ b/cute_tests/test_tap_listener.cpp
@@ -1,0 +1,118 @@
+#include "cute.h"
+#include "tap_listener.h"
+#include "test_tap_listener.h"
+#include <sstream>
+#include "cute_runner.h"
+#define MAKE_RUNNER_RUN_TO_OUT \
+		cute::tap_listener<> listen(out);\
+		cute::runner<cute::tap_listener<> > run(listen)
+
+
+void test_tap_emptyrun() {
+	std::ostringstream out;
+	{
+		cute::tap_listener<> listen(out);
+	}
+	ASSERT_EQUAL("",out.str());
+}
+void test_tap_single_success(){
+	std::ostringstream out;
+	{
+		MAKE_RUNNER_RUN_TO_OUT ;
+		run(CUTE(test_tap_emptyrun));
+	}
+	ASSERT_EQUAL(
+		"ok 1 test_tap_emptyrun\n"
+		"1..1\n",out.str());
+}
+
+void test_tap_failure() {
+	throw cute::test_failure("must fail","dummy.cpp",42);
+}
+
+void test_tap_single_failure(){
+	std::ostringstream out;
+	{
+		MAKE_RUNNER_RUN_TO_OUT ;
+		run(CUTE(test_tap_failure));
+	}
+
+	ASSERT_EQUAL(
+		"not ok 1 test_tap_failure\n"
+		"# Assertion failed: must fail\n"
+		"1..1\n",out.str());
+}
+
+void test_tap_suite(){
+	std::ostringstream out;
+	{
+		MAKE_RUNNER_RUN_TO_OUT;
+		cute::suite suite;
+		suite.push_back(CUTE(test_tap_failure));
+		suite.push_back(CUTE(test_tap_emptyrun));
+		run(suite,"tap_test_suite");
+	}
+	ASSERT_EQUAL(
+		"# Starting suite 'tap_test_suite' containing 2 tests\n"
+		"not ok 1 test_tap_failure\n"
+		"# Assertion failed: must fail\n"
+		"ok 2 test_tap_emptyrun\n"
+		"# Ending suite 'tap_test_suite'\n"
+		"1..2\n",out.str());
+}
+
+void test_tap_multiple_suites(){
+	std::ostringstream out;
+	{
+		MAKE_RUNNER_RUN_TO_OUT;
+		{
+			cute::suite suite;
+			suite.push_back(CUTE(test_tap_failure));
+			run(suite,"tap_test_suite_1");
+		}
+
+		{
+			cute::suite suite;
+			suite.push_back(CUTE(test_tap_emptyrun));
+			run(suite,"tap_test_suite_2");
+		}
+	}
+
+	ASSERT_EQUAL(
+		"# Starting suite 'tap_test_suite_1' containing 1 tests\n"
+		"not ok 1 test_tap_failure\n"
+		"# Assertion failed: must fail\n"
+		"# Ending suite 'tap_test_suite_1'\n"
+		"# Starting suite 'tap_test_suite_2' containing 1 tests\n"
+		"ok 2 test_tap_emptyrun\n"
+		"# Ending suite 'tap_test_suite_2'\n"
+		"1..2\n",out.str());
+}
+
+
+void test_tap_error(){
+	throw "oops";
+}
+
+void test_tap_for_error(){
+	std::ostringstream out;
+	{
+		MAKE_RUNNER_RUN_TO_OUT ;
+		run(CUTE(test_tap_error));
+	}
+	ASSERT_EQUAL(
+		"not ok 1 test_tap_error\n"
+		"# Unexpected exception: oops\n"
+		"1..1\n",out.str());
+}
+
+cute::suite make_suite_test_tap_listener(){
+	cute::suite s;
+	s.push_back(CUTE(test_tap_emptyrun));
+	s.push_back(CUTE(test_tap_single_success));
+	s.push_back(CUTE(test_tap_single_failure));
+	s.push_back(CUTE(test_tap_suite));
+	s.push_back(CUTE(test_tap_multiple_suites));
+	s.push_back(CUTE(test_tap_for_error));
+	return s;
+}

--- a/cute_tests/test_tap_listener.h
+++ b/cute_tests/test_tap_listener.h
@@ -1,0 +1,3 @@
+#include "cute_suite.h"
+
+extern cute::suite make_suite_test_tap_listener();


### PR DESCRIPTION
The Test Anything Protocol (TAP) is a test output protocol originally
created for Perl. Over the years, TAP has been adopted by various
languages and testing infrastructures. TAP is supported by different
test harnesses and can be used for automatic test result processing in
Jenkins, Automake, and others.

The tap_listener implements TAP version 12 which, according to the
specification, is considered the current release.