### PR TITLE
Indexed ASSERT's and checked throws

### DIFF
--- a/cute/cute_indexed.h
+++ b/cute/cute_indexed.h
@@ -1,0 +1,67 @@
+/*********************************************************************************
+ * This file is part of CUTE.
+ *
+ * Copyright (c) 2013-2018 Peter Sommerlad, IFS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *********************************************************************************/
+
+#ifndef CUTE_INDEXED_H_
+#define CUTE_INDEXED_H_
+
+#include "cute_base.h"
+#include "cute_equals.h"
+#include "cute_relops.h"
+#include "cute_throws.h"
+
+#define CUTE_INDEXMSG(msg, index) (std::string(msg) + " (" + #index + "=" + cute::cute_to_string::to_string(index) + ")")
+
+#define ASSERTMI(cond, msg, index) ASSERTM(cond, CUTE_INDEXMSG((msg), index))
+#define ASSERTI(cond, index) ASSERT_MI(cond, #cond, index)
+
+#define ASSERT_EQUALMI(msg, index, expected, actual) ASSERT_EQUALM(CUTE_INDEXMSG((msg), index), (expected), (actual))
+#define ASSERT_EQUALI(index, expected, actual) ASSERT_EQUALMI(#expected " == " #actual, index, (expected), (actual))
+#define ASSERT_EQUAL_DELTAMI(msg, index, expected, actual, delta) ASSERT_EQUAL_DELTAM(CUTE_INDEXMSG((msg), index), (expected), (actual), (delta))
+#define ASSERT_EQUAL_DELTAI(index, expected, actual, delta) ASSERT_EQUAL_DELTAMI(#expected " == " #actual " with error " #delta, index, (expected), (actual), (delta))
+
+#define ASSERT_LESSMI(msg, index, left, right) ASSERT_LESSM(CUTE_INDEXMSG((msg), index), (left), (right))
+#define ASSERT_LESSI(index, left, right, failure) ASSERT_LESSMI(#left " < " #right, index, (left), (right))
+
+#define ASSERT_LESS_EQUALMI(msg, index, left, right) ASSERT_LESS_EQUALM(CUTE_INDEXMSG((msg), index), (left), (right))
+#define ASSERT_LESS_EQUALI(index, left, right) ASSERT_LESS_EQUALMI(#left " <= " #right, index, (left), (right))
+
+#define ASSERT_GREATERMI(msg, index, left, right) ASSERT_GREATERM(CUTE_INDEXMSG((msg), index), (left), (right))
+#define ASSERT_GREATERI(index, left, right, failure) ASSERT_GREATERMI(#left " > " #right, index, (left), (right))
+
+#define ASSERT_GREATER_EQUALMI(msg, index, left, right) ASSERT_GREATER_EQUALM(CUTE_INDEXMSG((msg), index), (left), (right))
+#define ASSERT_GREATER_EQUALI(index, left, right) ASSERT_GREATER_EQUALMI(#left " >= " #right, index, (left), (right))
+
+#define ASSERT_NOT_EQUAL_TOMI(msg, index, left, right) ASSERT_NOT_EQUAL_TOM(CUTE_INDEXMSG((msg), index), (left), (right))
+#define ASSERT_NOT_EQUAL_TOI(index, left, right) ASSERT_NOT_EQUAL_TOMI(#left " != " #right, index, (left), (right))
+
+#define ASSERT_THROWSMI(anuncommonmessagetextparametername, index, code, exc) ASSERT_THROWSM(CUTE_INDEXMSG(anuncommonmessagetextparametername, index), code, exc)
+#define ASSERT_THROWSI(index, code, exc) ASSERT_THROWSMI(" expecting " #code " to throw " #exc, index, code, exc)
+
+#define ASSERT_THROWS_CHECKMI(anuncommonmessagetextparametername, index, code, exc, check_code) ASSERT_THROWS_CHECKM(CUTE_INDEXMSG(anuncommonmessagetextparametername, index), code, exc, check_code)
+#define ASSERT_THROWS_CHECKI(index, code, exc, check_code) ASSERT_THROWS_CHECKMI(" expecting " #code " to throw " #exc, index, code, exc, check_code)
+
+//#undef INDEXMSG
+
+#endif /* CUTE_DATA_DRIVEN_H_ */

--- a/cute/cute_throws.h
+++ b/cute/cute_throws.h
@@ -50,4 +50,16 @@ namespace cute {
 	} while(0)
 #define ASSERT_THROWS(code,exc) ASSERT_THROWSM(" expecting " #code " to throw " #exc,code,exc)
 
+#define ASSERT_THROWS_CHECKM(anuncommonmessagetextparametername,code,exc, check_code) \
+	do { \
+		try { \
+			{ code ; } \
+			throw cute::do_not_use_this_namespace::assert_throws_failure_exception((anuncommonmessagetextparametername),__FILE__,__LINE__); \
+		} catch(exc const &e){ \
+			check_code ; \
+		} catch(cute::do_not_use_this_namespace::assert_throws_failure_exception const &atf){throw atf.original;} \
+	} while(0)
+#define ASSERT_THROWS_CHECK(code,exc,check_code) ASSERT_THROWS_CHECKM(" expecting " #code " to throw " #exc,code,exc,check_code)
+
+
 #endif /*CUTE_THROWS_H_*/

--- a/cute_example/simpletest.cpp
+++ b/cute_example/simpletest.cpp
@@ -36,7 +36,7 @@ void mySimpleTest(){
 #include <iostream>
 
 void main1(){
-	cute::ide_listener<> listener{};
+    cute::ide_listener<> listener{};
     if (cute::makeRunner(listener)(mySimpleTest)){
         std::cout << "success\n";
     } else {
@@ -53,34 +53,91 @@ void main2(){
 #include "cute_equals.h"
 
 int anotherTest(){
-	ASSERT_EQUAL(42, lifeTheUniverseAndEverything);
-	return 0;
+    ASSERT_EQUAL(42, lifeTheUniverseAndEverything);
+    return 0;
 }
 
 cute::test tests[]={
-	CUTE(mySimpleTest)
-	,mySimpleTest
-	,CUTE(anotherTest)
+    CUTE(mySimpleTest)
+    ,mySimpleTest
+    ,CUTE(anotherTest)
 };
 
 struct ATestFunctor {
-	void operator()(){
-		ASSERT_EQUAL_DELTA(42.0, static_cast<double>(lifeTheUniverseAndEverything), 0.001);
-	}
+    void operator()(){
+        ASSERT_EQUAL_DELTA(42.0, static_cast<double>(lifeTheUniverseAndEverything), 0.001);
+    }
 };
 
 #include "cute_suite.h"
 
 int main3(){
-	cute::ide_listener<> listener{};
+    cute::ide_listener<> listener{};
     auto run = cute::makeRunner(listener);
     cute::suite s(tests, tests + (sizeof(tests) / sizeof(tests[0])));
-	s += ATestFunctor();
-	return run(s, "suite");
+    s += ATestFunctor();
+    return run(s, "suite");
+    }
+
+#include "cute_indexed.h"
+
+struct Point3d {
+    int x, y, z;
+};
+
+Point3d makePoint(int i) {
+#ifdef FAIL_INDEXED_TEST
+    return Point3d{i, i + 1, i - 1};
+#else
+    return i == 5 ? Point3d{i, i, i} : Point3d{i, i + 1, i - 1};
+#endif 
+}
+
+struct Exception {
+    int code_; 
+    explicit Exception(int code) : code_(code) { }
+};
+
+void throwException(int code) {
+#ifdef FAIL_CHECKED_THROWS_TEST
+    throw Exception(code + 1);
+#else 
+    throw Exception(code);
+#endif
+}
+
+void testIndexed() {
+    for(int i = 0; i < 10; ++i) {
+        const auto refPoint = i == 5 ? Point3d{i, i, i} : Point3d{i, i + 1, i - 1};
+        const auto point = makePoint(i);
+        ASSERT_EQUALI(i, refPoint.x, point.x);
+        ASSERT_EQUALI(i, refPoint.y, point.y);
+        ASSERT_EQUALI(i, refPoint.z, point.z);
+    }
+}
+
+void testCheckedThrow() {
+    ASSERT_THROWS(throwException(0), Exception);
+    ASSERT_THROWS_CHECK(throwException(0), Exception, 
+        ASSERT_EQUAL(0, e.code_));
+}
+  
+
+int main4() {
+    static const cute::test tests[] = {
+        CUTE(testIndexed),
+        CUTE(testCheckedThrow),
+    };
+
+    cute::ide_listener<> listener{};
+    auto run = cute::makeRunner(listener);
+    cute::suite s(tests, tests + (sizeof(tests) / sizeof(tests[0])));
+    return run(s, "new test suite");
 }
 
 int main(){
-	main1();
-	main2();
-	main3();
+    main1();
+    main2();
+    main3();
+    main4();
 }


### PR DESCRIPTION
Hi, I've added a couple of features that I find useful for my data-driven tests.

The first one is an ability to include an index reference into the failure messages while keeping the (autogenerated) condition message intact. Please see a usage example in the testIndexed() function. 

The second one is an ability to provide a specific code for checking properties of a thrown message. So that not only the fact of the given exception being thrown is checked, but e.g. a status code can be also verified. Please see a usage example in the testCheckedThrow() function.